### PR TITLE
Fixed the app crashing for some users

### DIFF
--- a/mond/helpers/utils.swift
+++ b/mond/helpers/utils.swift
@@ -29,11 +29,13 @@ func is_supported() -> Bool {
            v.patchVersion == 0
 }
 
-func hasHomeButton() -> Bool {
+// Unused for now
+// Was causing KERN_INVALID_ADDRESS at 0x0000000000000001 on my iPhone SE 2 crashing the app when opening -- aokumo21
+/*func hasHomeButton() -> Bool {
     let sel = NSSelectorFromString("_hasHomeButton")
     return UIDevice.responds(to: sel) &&
         (UIDevice.perform(sel)?.takeUnretainedValue() as? Bool ?? false)
-}
+*/}
 
 enum AppPaths {
     static var backups: String {

--- a/mond/helpers/utils.swift
+++ b/mond/helpers/utils.swift
@@ -35,7 +35,7 @@ func is_supported() -> Bool {
     let sel = NSSelectorFromString("_hasHomeButton")
     return UIDevice.responds(to: sel) &&
         (UIDevice.perform(sel)?.takeUnretainedValue() as? Bool ?? false)
-*/}
+}*/
 
 enum AppPaths {
     static var backups: String {

--- a/mond/views/ContentView.swift
+++ b/mond/views/ContentView.swift
@@ -91,10 +91,7 @@ struct ContentView: View {
                         if doubleSystemVersion() >= 26.0 {
                             Text("iPhone Air").tag(2736)
                         }
-                        // temp test
-                        //if hasHomeButton() {
-                        //    Text("iPhone X Gestures").tag(2436)
-                        //}
+                        Text("iPhone X Gestures (iPhone SE Only)").tag(2436) // I don't know how to check for the home button so this is the best I can do - aokumo21
                     } label: {
                         HStack {
                             Text("Subtype")
@@ -127,10 +124,9 @@ struct ContentView: View {
                     PlainToggle(text: "Camera Control", minSupportedVersion: 18.0, isOn: mg_key_binding(["CwvKxM2cEogD3p+HYgaW0Q", "oOV1jhJbdV3AddkcCg0AEA"]))
                     PlainToggle(text: "Action Button", minSupportedVersion: 17.0, isOn: mg_key_binding(["cT44WE1EohiwRzhsZ8xEsw"]))
                     PlainToggle(text: "Crash Detection", isOn: mg_key_binding(["HCzWusHQwZDea6nNhaKndw"]))
-                    // temp test
-                    //if hasHomeButton() {
-                    //    PlainToggle(text: "Enable Tap to Wake", isOn: mg_key_binding(["yZf3GTRMGTuwSV/lD7Cagw"]))
-                    //}
+                    
+                    PlainToggle(text: "Enable Tap to Wake (iPhone SE Only)", isOn: mg_key_binding(["yZf3GTRMGTuwSV/lD7Cagw"])) // I don't know how to check for the home button so this is the best I can do - aokumo21
+                    
                     PlainToggle(text: "Pulse Width Modulation", minSupportedVersion: 19.0, isOn: mg_key_binding(["6IejgN+1Fmu5/QrZFOIeNw"]))
                 } header: {
                     Label("Hardware-Oriented Features", systemImage: "iphone")

--- a/mond/views/ContentView.swift
+++ b/mond/views/ContentView.swift
@@ -91,9 +91,10 @@ struct ContentView: View {
                         if doubleSystemVersion() >= 26.0 {
                             Text("iPhone Air").tag(2736)
                         }
-                        if hasHomeButton() {
-                            Text("iPhone X Gestures").tag(2436)
-                        }
+                        // temp test
+                        //if hasHomeButton() {
+                        //    Text("iPhone X Gestures").tag(2436)
+                        //}
                     } label: {
                         HStack {
                             Text("Subtype")
@@ -126,9 +127,10 @@ struct ContentView: View {
                     PlainToggle(text: "Camera Control", minSupportedVersion: 18.0, isOn: mg_key_binding(["CwvKxM2cEogD3p+HYgaW0Q", "oOV1jhJbdV3AddkcCg0AEA"]))
                     PlainToggle(text: "Action Button", minSupportedVersion: 17.0, isOn: mg_key_binding(["cT44WE1EohiwRzhsZ8xEsw"]))
                     PlainToggle(text: "Crash Detection", isOn: mg_key_binding(["HCzWusHQwZDea6nNhaKndw"]))
-                    if hasHomeButton() {
-                        PlainToggle(text: "Enable Tap to Wake", isOn: mg_key_binding(["yZf3GTRMGTuwSV/lD7Cagw"]))
-                    }
+                    // temp test
+                    //if hasHomeButton() {
+                    //    PlainToggle(text: "Enable Tap to Wake", isOn: mg_key_binding(["yZf3GTRMGTuwSV/lD7Cagw"]))
+                    //}
                     PlainToggle(text: "Pulse Width Modulation", minSupportedVersion: 19.0, isOn: mg_key_binding(["6IejgN+1Fmu5/QrZFOIeNw"]))
                 } header: {
                     Label("Hardware-Oriented Features", systemImage: "iphone")


### PR DESCRIPTION
Commented out the `hasHomeButton()` function as it was causing a EXC_BAD_ACCESS exception due to `KERN_INVALID_ADDRESS at 0x0000000000000001`

I had this issue on my iPhone SE 2 running iOS 27.0 db4 (24A5390f)

Fix for #8 and #6.
Possibly #1 but idk since they haven't uploaded a log.

I've replaced the function by appending text onto the end of the two options which used it saying "(iPhone SE Only)".
This does however mean the option is visible for none home button devices.
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/71f13aa6-ed76-4585-9356-8c5b8d665302" />
