### PR TITLE
Fix iOS 27 region restrictions and MobileGestalt persistence

### DIFF
--- a/mond/helpers/mg.swift
+++ b/mond/helpers/mg.swift
@@ -171,13 +171,13 @@ let all_tweaks: [mg_tweak] = [
         info_msg: "This tweak may be broken or have no effect on some iOS versions or devices.",
         r: { dict in
             guard let cache_extra = dict["CacheExtra"] as? NSMutableDictionary else { return false }
-            return cache_extra[region_code_key] as? String == "US" &&
+            return cache_extra[region_code_key] as? String == "LL" &&
                    cache_extra[region_info_key] as? String == "LL/A"
         },
         w_on: { dict in
             guard let cache_extra = dict["CacheExtra"] as? NSMutableDictionary else { return }
             Alertinator.shared.alert(title: "Warning!", body: "Please do not use this feature to bypass region restrictions that would equate to breaking regional laws (e.g. disabling the camera shutter sound). We will NOT be held responsible for enabling any illegal activites!")
-            cache_extra[region_code_key] = "US"
+            cache_extra[region_code_key] = "LL"
             cache_extra[region_info_key] = "LL/A"
         },
         w_off: { dict in

--- a/mond/helpers/mg.swift
+++ b/mond/helpers/mg.swift
@@ -140,6 +140,9 @@ extension mg_tweak {
     }
 }
 
+private let region_code_key = "h63QSdBCiT/z0WU6rdQv6Q"
+private let region_info_key = "yK+xavymRGZ3xWc1tb8XDg"
+
 let all_tweaks: [mg_tweak] = [
     mg_tweak(title: "Enable Dynamic Island Capability", minv: 19.0, key: "YlEtTtHlNesRBMal1CqRaA", value: 1, info_t: .info, info_msg: "An alternate way to enable the Dynamic Island, as used by Nugget."),
     mg_tweak(title: "Always-On Display", minv: 18.0, keys: ["2OOJf1VhaM7NxfRok3HbWQ", "j8/Omm6s1lsmTDFsXjsBfA"], value: 1, info_t: .warning, info_msg: "Can increase screen burn-in risk on devices that don't officially support it."),
@@ -168,19 +171,19 @@ let all_tweaks: [mg_tweak] = [
         info_msg: "This tweak may be broken or have no effect on some iOS versions or devices.",
         r: { dict in
             guard let cache_extra = dict["CacheExtra"] as? NSMutableDictionary else { return false }
-            return cache_extra["h63QSdBCiT/z0WU6rdQv6Q"] as? String == "US" &&
-                   cache_extra["zHeENZu+wbg7PUprwNwBWg"] as? String == "LL/A"
+            return cache_extra[region_code_key] as? String == "US" &&
+                   cache_extra[region_info_key] as? String == "LL/A"
         },
         w_on: { dict in
             guard let cache_extra = dict["CacheExtra"] as? NSMutableDictionary else { return }
             Alertinator.shared.alert(title: "Warning!", body: "Please do not use this feature to bypass region restrictions that would equate to breaking regional laws (e.g. disabling the camera shutter sound). We will NOT be held responsible for enabling any illegal activites!")
-            cache_extra["h63QSdBCiT/z0WU6rdQv6Q"] = "US"
-            cache_extra["zHeENZu+wbg7PUprNwBWg"] = "LL/A"
+            cache_extra[region_code_key] = "US"
+            cache_extra[region_info_key] = "LL/A"
         },
         w_off: { dict in
             guard let cache_extra = dict["CacheExtra"] as? NSMutableDictionary else { return }
-            cache_extra.removeObject(forKey: "h63QSdBCiT/z0WU6rdQv6Q")
-            cache_extra.removeObject(forKey: "zHeENZu+wbg7PUprNwBWg")
+            cache_extra.removeObject(forKey: region_code_key)
+            cache_extra.removeObject(forKey: region_info_key)
         }
     ),
     

--- a/mond/mond.swift
+++ b/mond/mond.swift
@@ -37,7 +37,10 @@ struct mond: App {
             dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
         }
         
-        UserDefaults.standard.register(defaults: ["method": "bad_query"])
+        UserDefaults.standard.register(defaults: [
+            "method": "bad_query",
+            "atomic_write": true
+        ])
         if UserDefaults.standard.bool(forKey: "ka_on") {
             keep_alive()
         }


### PR DESCRIPTION
## Summary

- Fix Disable Region Restrictions on iOS 27 and make Persist after reboot use in-place writes by default.

## Testing

- Tested successfully on iPad Air 5 running iPadOS 27.0 Developer Beta 4.
- Confirmed modified MobileGestalt values remain after reboot.